### PR TITLE
add a bucket policy enforcing ssl access for created s3 buckets

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -20,3 +20,28 @@ resource "aws_s3_bucket_public_access_block" "alarm_templates" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_policy" "alarm_templates_policy" {
+  bucket = aws_s3_bucket.alarm_templates.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid = "RequireSSL",
+        Effect = "Deny",
+        Principal = "*",
+        Action = "s3:*",
+        Resource = [
+          aws_s3_bucket.alarm_templates.arn,
+          "${aws_s3_bucket.alarm_templates.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
This change enforces SSL access on the created S3 buckets.

Note that this PR is to merge into the `terraform-upgrade` branch, which is being referred to elsewhere.