### PR TITLE
Enable bucket encryption

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -10,6 +10,15 @@ resource "aws_s3_bucket" "alarm_templates" {
   acl    = "private"
 
   tags = var.bucket-tags
+  
+  server_side_encryption_configuration {
+    rule {
+        bucket_key_enabled = false
+        apply_server_side_encryption_by_default {
+            sse_algorithm = "AES256"
+        }
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "alarm_templates" {


### PR DESCRIPTION
We have noise in our Terraform plan. I have the impression that this is related to default encryption ( https://aws.amazon.com/blogs/aws/amazon-s3-encrypts-new-objects-by-default/ ) recently introduced.

Let's apply that to avoid perpetual diff.